### PR TITLE
Correctly handle generics and type aliases

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -59,6 +59,14 @@ func (*ExampleBaz) H(ctx context.Context) (*generic.MyGeneric[util.MyUtil], erro
 	return nil, nil
 }
 
+func (*ExampleBaz) I(ctx context.Context) (*generic.MyGenericAlias, error) {
+	return nil, nil
+}
+
+func (*ExampleBaz) J(ctx context.Context) (*generic.MyGenericAliasWithTypeArg[int], error) {
+	return nil, nil
+}
+
 func ExampleNew() {
 	i, err := interfaces.New(`github.com/rjeczalik/interfaces.ExampleBaz`)
 	if err != nil {
@@ -73,7 +81,8 @@ func ExampleNew() {
 	for _, dep := range i.Deps() {
 		fmt.Println(dep)
 	}
-	// Output: Interface:
+	// Output:
+	// Interface:
 	// A(int) int
 	// B(*string, io.Writer, interfaces_test.ExampleFoo) (*interfaces_test.ExampleFoo, int)
 	// C(map[string]int, *interfaces.Options, *http.Client) (chan []string, error)
@@ -82,13 +91,14 @@ func ExampleNew() {
 	// F(interfaces_test.Generic1[io.Writer]) (interfaces_test.Generic2[io.Writer, interfaces_test.ExampleFoo], int)
 	// G(interfaces_test.Generic2[string, io.Writer]) (interfaces_test.Generic1[int], int)
 	// H(context.Context) (*generic.MyGeneric[util.MyUtil], error)
+	// I(context.Context) (*generic.MyGenericAlias, error)
+	// J(context.Context) (*generic.MyGenericAliasWithTypeArg[int], error)
 	// Dependencies:
 	// context
 	// flag
 	// github.com/rjeczalik/interfaces
 	// github.com/rjeczalik/interfaces/testdata/generic
 	// github.com/rjeczalik/interfaces/testdata/util
-
 	// github.com/rjeczalik/interfaces_test
 	// io
 	// net/http

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/rjeczalik/interfaces
 
-go 1.21.9
-
-toolchain go1.22.2
+go 1.23.0
 
 require golang.org/x/tools v0.20.0
 

--- a/testdata/generic/types.go
+++ b/testdata/generic/types.go
@@ -1,5 +1,13 @@
 package generic
 
+import (
+	"github.com/rjeczalik/interfaces/testdata/util"
+)
+
 type MyGeneric[A any] struct {
 	Value []A
 }
+
+type MyGenericAlias = MyGeneric[util.MyUtil]
+
+type MyGenericAliasWithTypeArg[B any] = MyGeneric[B]


### PR DESCRIPTION
I initially started looking into an issue with generating code for a generic type alias and as I was looking into it found this:

The `ExampleNew()` test was never ran due to a new line in the output:
```
	// github.com/rjeczalik/interfaces/testdata/util

	// github.com/rjeczalik/interfaces_test
```

After fixing this I discovered two things:
1. Generic arguments for built in types were not properly handled (i.e. MyGeneric[string] would fail to parse) 
2. The original package author added "support" for type aliases but never bumped the go version of the package, meaning the new `*types.Alias` type was never actually used. This means the aliases were not being processed properly.

This PR fixes code gen for the following functions:

```go
func (*ExampleBaz) F(v Generic1[io.Writer]) (Generic2[io.Writer, ExampleFoo], int) {
	return Generic2[io.Writer, ExampleFoo]{}, 0
}
func (*ExampleBaz) G(v Generic2[string, io.Writer]) (Generic1[int], int) {
	return Generic1[int]{}, 0
}
func (*ExampleBaz) H(ctx context.Context) (*generic.MyGeneric[util.MyUtil], error) {
	return nil, nil
}

func (*ExampleBaz) I(ctx context.Context) (*generic.MyGenericAlias, error) {
	return nil, nil
}

func (*ExampleBaz) J(ctx context.Context) (*generic.MyGenericAliasWithTypeArg[int], error) {
	return nil, nil
}
```

After removing the new line from the example, these examples fail to pass without the changes in this PR. I added two new tests to ensure type aliases are working as expected. 

I decided to modify the original author's type alias handling a bit since with his implementation the function:
```go
func (*ExampleBaz) I(ctx context.Context) (*generic.MyGenericAlias, error) {
	return nil, nil
}
```

would generate:
```go
func (*ExampleBaz) H(ctx context.Context) (*generic.MyGeneric[util.MyUtil], error) {
	return nil, nil
}
```

I didn't like that the interface didn't use the alias type, we defined the original function with an alias type for a reason, so it should be used. While debugging it turned out I can treat `*types.Alias` and `*types.Named` the same, so I created an interface to reduce code duplication.